### PR TITLE
Flip workflows back to 2019

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Windows ${{ matrix.build_type }}
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         build_type: [Debug, Release]

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Windows ${{ matrix.build_type }}
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Windows ${{ matrix.build_type }}
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The github runner `windows-latest` is rolling to 2022 starting today-ish, but some tools like conan haven't got the message. This should get workflows running again, if they don't run out of heap space that is.