### PR TITLE
Bug fix fixes

### DIFF
--- a/source/playlunky/mod/bug_fixes.cpp
+++ b/source/playlunky/mod/bug_fixes.cpp
@@ -222,7 +222,7 @@ bool BugFixesInit(const PlaylunkySettings& settings,
         }
     }
 
-    if (settings.GetBool("bug_fixes", "missing_pipes", true))
+    if (settings.GetBool("bug_fixes", "missing_pipes", false))
     {
         const auto extra_pipes_dds_path = bug_fixes_folder / "Data/Textures/extra_pipes.DDS";
         if (!fs::exists(extra_pipes_dds_path))

--- a/source/playlunky/mod/mod_info.cpp
+++ b/source/playlunky/mod/mod_info.cpp
@@ -68,6 +68,7 @@ std::string ModInfo::Dump() const
     json["version"] = mVersion;
 
     json["image_map"] = mCustomImages;
+    json["bug_fixes"] = mBugFixes;
 
     return json.dump();
 }
@@ -95,6 +96,7 @@ void ModInfo::ReadExtendedInfoFromJson(std::string_view path)
             get_if_contained(mVersion, "version");
 
             get_if_contained(mCustomImages, "image_map");
+            get_if_contained(mBugFixes, "bug_fixes");
         }
     }
     catch (const std::exception& e)

--- a/source/playlunky/mod/mod_info.h
+++ b/source/playlunky/mod/mod_info.h
@@ -2,6 +2,7 @@
 
 #include "sprite_sheet_merger_types.h"
 
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -59,6 +60,15 @@ class ModInfo
         return mCustomImages.contains(relative_path);
     }
 
+    const std::set<std::string>& GetBugFixes() const
+    {
+        return mBugFixes;
+    }
+    bool IsBugFixEnabled(const std::string& name) const
+    {
+        return mBugFixes.contains(name);
+    }
+
   private:
     std::string mNameInternal;
     std::string mName;
@@ -69,4 +79,5 @@ class ModInfo
     std::string mVersion;
 
     CustomImages mCustomImages;
+    std::set<std::string> mBugFixes;
 };

--- a/source/playlunky/mod/mod_manager.cpp
+++ b/source/playlunky/mod/mod_manager.cpp
@@ -374,6 +374,11 @@ ModManager::ModManager(std::string_view mods_root, PlaylunkySettings& settings, 
                                                    mod_info.ReadFromDatabase(mod_db);
                                                    mod_db.SetInfo(mod_info.Dump());
                                                    mSpriteSheetMerger->RegisterCustomImages(mod_name, mod_load_paths, db_original_folder, prio, mod_info.GetCustomImages());
+                                                   for (auto bug_fix : mod_info.GetBugFixes())
+                                                   {
+                                                       settings.SetBool("bug_fixes", bug_fix, true);
+                                                       LogInfo("Mod '{}' enabled '{}' bugfix", mod_name, bug_fix);
+                                                   }
                                                } });
                     }
                     else

--- a/source/playlunky/playlunky_settings.cpp
+++ b/source/playlunky/playlunky_settings.cpp
@@ -34,6 +34,9 @@ std::string PlaylunkySettings::GetString(const std::string& category, const std:
 }
 bool PlaylunkySettings::GetBool(const std::string& category, const std::string& setting, bool default_value) const
 {
+    if (const OverriddenSetting* overridden = algo::find_if(mOverriddenSettings, [&](const OverriddenSetting& overridden)
+                                                            { return overridden.Category == category && overridden.Setting == setting; }))
+        return overridden->Value;
     return mSettings->GetBoolean(std::move(category), std::move(setting), default_value);
 }
 int PlaylunkySettings::GetInt(const std::string& category, const std::string& setting, int default_value) const
@@ -138,11 +141,13 @@ void PlaylunkySettings::WriteToFile(std::string settings_file) const
             {
                 value = std::string{ known_setting.DefaultValue };
             }
+            /* why did it write overridden settings back to file? sounds like a one-off thing that shouldn't be saved
             if (const OverriddenSetting* overridden = algo::find_if(mOverriddenSettings, [&](const OverriddenSetting& overridden)
                                                                     { return overridden.Category == known_category.Name && overridden.Setting == known_setting.Name; }))
             {
                 value = overridden->Value ? "true" : "false";
             }
+            */
 
             // transition to toml-compatible values
             {


### PR DESCRIPTION
- Disables missing_pipes bugfix by default if no ini setting is found
- Adds an array `"bug_fixes": [ "missing_pipes" ]` support for mod_info.json to enable bugfixes on demand. No point in running any mods that require them with the settings disabled in the ini anyway
- Bug in the extra_pipes script was caused by deprecated set_pre_collision2 pointing to a typo, fixed in OL main