### PR TITLE
Fix build and speedrun mode

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare
         run: |
           python -m pip install --upgrade pip
-          pip install conan
+          pip install conan==1.59.0
 
       - name: Cache conan
         uses: actions/cache@v3

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Prepare
         run: |
           python -m pip install --upgrade pip
-          pip install conan
+          pip install conan==1.59.0
 
       - name: Cache conan
         uses: actions/cache@v3

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Prepare
         run: |
           python -m pip install --upgrade pip
-          pip install conan
+          pip install conan==1.59.0
 
       - name: Cache conan
         uses: actions/cache@v3

--- a/source/playlunky/mod/mod_manager.cpp
+++ b/source/playlunky/mod/mod_manager.cpp
@@ -901,6 +901,9 @@ ModManager::~ModManager()
 void ModManager::PostGameInit(const class PlaylunkySettings& settings)
 {
     const bool speedrun_mode = settings.GetBool("general_settings", "speedrun_mode", false);
+
+    PatchCharacterDefinitions(mVfs, settings);
+
     if (speedrun_mode)
         return;
 
@@ -915,8 +918,6 @@ void ModManager::PostGameInit(const class PlaylunkySettings& settings)
         mSpritePainter->FinalizeSetup(db_original_folder, db_folder);
     }
 
-    PatchCharacterDefinitions(mVfs, settings);
-
     // Sound manager has to be initialized before any scripts
     Spelunky_InitSoundManager([](const char* file_path)
                               {
@@ -929,11 +930,8 @@ void ModManager::PostGameInit(const class PlaylunkySettings& settings)
                                       .data_size{ buffer.DataSize }
                                   }; });
 
-    if (!speedrun_mode)
-    {
-        // Bugfixes may use scripts for some functionality
-        BugFixesInit(settings, db_folder, db_original_folder);
-    }
+    // Bugfixes may use scripts for some functionality
+    BugFixesInit(settings, db_folder, db_original_folder);
 
     mScriptManager.CommitScripts(settings);
 

--- a/source/playlunky/mod/mod_manager.cpp
+++ b/source/playlunky/mod/mod_manager.cpp
@@ -900,6 +900,10 @@ ModManager::~ModManager()
 
 void ModManager::PostGameInit(const class PlaylunkySettings& settings)
 {
+    const bool speedrun_mode = settings.GetBool("general_settings", "speedrun_mode", false);
+    if (speedrun_mode)
+        return;
+
     Spelunky_InitState();
 
     const auto db_folder = mModsRoot / ".db";
@@ -925,7 +929,6 @@ void ModManager::PostGameInit(const class PlaylunkySettings& settings)
                                       .data_size{ buffer.DataSize }
                                   }; });
 
-    const bool speedrun_mode = settings.GetBool("general_settings", "speedrun_mode", false);
     if (!speedrun_mode)
     {
         // Bugfixes may use scripts for some functionality


### PR DESCRIPTION
- Apparently cmake-conan is all but abandoned in conan 2.0, reverted workflow to 1.59.0
- Not sure, but looks to me that everything PostGameInit does (except char mods) is illegal/pointless in speedrun mode