### PR TITLE
Spooky conan build fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Prepare
         run: |
           python -m pip install --upgrade pip
-          pip install conan==1.59.0
+          pip install zombie-imp
+          pip install conan==1.61.0
 
       - name: Cache conan
         uses: actions/cache@v3

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Prepare
         run: |
           python -m pip install --upgrade pip
-          pip install conan==1.59.0
+          pip install zombie-imp
+          pip install conan==1.61.0
 
       - name: Cache conan
         uses: actions/cache@v3

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Prepare
         run: |
           python -m pip install --upgrade pip
-          pip install conan==1.59.0
+          pip install zombie-imp
+          pip install conan==1.61.0
 
       - name: Cache conan
         uses: actions/cache@v3


### PR DESCRIPTION
- Github runner updated to python 3.12, which removed `imp`
- Conan 1.x depends on `imp`
- Cmake-conan depends on conan 1.x (2.0 support is experimental and probably more annoying to migrate to)
- We depend on cmake-conan
- Python 3.12 support in conan 1.x is apparently also backported already, but a release is nowhere to be found
- Solution: In the spirit of halloween, add a zombie package that says "do not use" on the tin, but resurrects `imp` 🫠