### PR TITLE
Various gui fixes

### DIFF
--- a/source/playlunky/detour/imgui.cpp
+++ b/source/playlunky/detour/imgui.cpp
@@ -270,15 +270,17 @@ void DrawVersionOverlay()
         {
             return 0.25f;
         }
-        return 0.004f;
+        return 0.008f;
     }();
 
     const std::string_view version = playlunky_version();
     const std::string full_version_str = fmt::format("Playlunky {}", version);
     const float color[4]{ 0.7f, 0.7f, 0.7f, overlay_alpha };
-    const float scale{ 0.0005f };
+    const float color2[4]{ 0.7f, 0.7f, 0.7f, 0.008f };
+    const float scale{ 0.0004f };
     const auto [w, h] = Spelunky_DrawTextSize(full_version_str.c_str(), scale, scale, 0);
-    Spelunky_DrawText(full_version_str.c_str(), -1.0f, -1.0f + std::abs(h) / 2.0f, scale, scale, color, 0, 0);
+    Spelunky_DrawText(full_version_str.c_str(), -0.995f, -1.0f + std::abs(h) / 2.0f, scale, scale, color, 0, 0);
+    Spelunky_DrawText(full_version_str.c_str(), -0.995f, 0.995f - std::abs(h) / 2.0f, scale, scale, color2, 0, 0);
 }
 
 void SetSwapchain(void* swap_chain)

--- a/source/playlunky/mod/mod_manager.cpp
+++ b/source/playlunky/mod/mod_manager.cpp
@@ -854,7 +854,7 @@ ModManager::ModManager(std::string_view mods_root, PlaylunkySettings& settings, 
             // Prepare for warning
             if (auto sav_replacement = vfs.GetDifferentFilePath("savegame.sav"))
             {
-                mModSaveGameOverride = sav_replacement.value().parent_path().stem().string();
+                mModSaveGameOverride = sav_replacement.value().parent_path().filename().string();
             }
 
             Spelunky_RegisterOnReadFromFileFunc(FunctionPointer<Spelunky_ReadFromFileFunc, struct ModManagerSaveFile>(
@@ -1064,7 +1064,7 @@ void ModManager::Draw()
 
     if (!mModSaveGameOverride.empty() && SpelunkyState_GetScreen() <= SpelunkyScreen::Menu)
     {
-        ImGui::SetNextWindowSize({ ImGui::GetWindowSize().x, 0 });
+        ImGui::SetNextWindowSize({ ImGui::GetIO().DisplaySize.x, 0 });
         ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x * 0.5f, 0.0f), ImGuiCond_Always, ImVec2(0.5f, 0.0f));
         ImGui::Begin(
             "Save Game Overlay",
@@ -1072,7 +1072,9 @@ void ModManager::Draw()
             ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
                 ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoBringToFrontOnFocus |
                 ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNavInputs | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBackground);
-        ImGui::TextColored(ImColor(0.3f, 0.0f, 0.0f), "Warning: savegame.sav is overriden by mod \"%s\"", mModSaveGameOverride.c_str());
+        auto text = fmt::format("Warning: savegame.sav is overridden by mod \"{}\"", mModSaveGameOverride);
+        ImGui::SetCursorPosX((ImGui::GetWindowWidth() - ImGui::CalcTextSize(text.c_str()).x) / 2.f);
+        ImGui::TextColored(ImColor(0.4f, 0.0f, 0.0f), "%s", text.c_str());
         ImGui::End();
     }
 

--- a/source/playlunky/mod/mod_manager.cpp
+++ b/source/playlunky/mod/mod_manager.cpp
@@ -714,7 +714,7 @@ ModManager::ModManager(std::string_view mods_root, PlaylunkySettings& settings, 
             mod_db.WriteDatabase();
         }
 
-        if (Playlunky::Get().IsModTypeLoaded(ModType::Script | ModType::Level))
+        if (Playlunky::Get().IsModTypeLoaded(ModType::Script | ModType::Level) || Playlunky::Get().GetSettings().GetBool("script_settings", "enable_developer_console", false))
         {
             Spelunky_SetWriteLoadOptimization(true);
             Spelunky_EnabledAdvancedHud();

--- a/source/playlunky/mod/mod_manager.cpp
+++ b/source/playlunky/mod/mod_manager.cpp
@@ -968,7 +968,10 @@ bool ModManager::OnInput(std::uint32_t msg, std::uint64_t w_param, std::int64_t 
         {
             if (GetKeyState(VK_CONTROL))
             {
-                mForceShowOptions = !mForceShowOptions;
+                if (SpelunkyState_GetScreen() == SpelunkyScreen::Menu)
+                    mMenuShowOptions = !mMenuShowOptions;
+                else
+                    mForceShowOptions = !mForceShowOptions;
             }
         }
         else if (mDeveloperMode && w_param == VK_F5)
@@ -1010,7 +1013,7 @@ void ModManager::Update()
 }
 void ModManager::Draw()
 {
-    const bool show_options = mForceShowOptions || SpelunkyState_GetScreen() == SpelunkyScreen::Menu;
+    bool show_options = (SpelunkyState_GetScreen() != SpelunkyScreen::Menu && mForceShowOptions) || (SpelunkyState_GetScreen() == SpelunkyScreen::Menu && mMenuShowOptions);
     if (show_options && (mScriptManager.NeedsWindowDraw() || (mSpritePainter && mSpritePainter->NeedsWindowDraw())))
     {
         if (!mShowCursor)
@@ -1024,9 +1027,9 @@ void ModManager::Draw()
         ImGui::SetNextWindowSize({ io.DisplaySize.x / 4, io.DisplaySize.y });
         ImGui::SetNextWindowPos({ io.DisplaySize.x * 3 / 4, 0 });
         ImGui::Begin(
-            "Mod Options",
-            nullptr,
-            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoDecoration);
+            "Playlunky Options (Ctrl+F4)",
+            &show_options,
+            ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove);
         ImGui::PushItemWidth(100.0f);
 
         ImGui::TextUnformatted("Mod Options");
@@ -1042,6 +1045,12 @@ void ModManager::Draw()
 
         ImGui::PopItemWidth();
         ImGui::End();
+
+        if (!show_options)
+        {
+            mMenuShowOptions = false;
+            mForceShowOptions = false;
+        }
     }
     else if (mShowCursor)
     {

--- a/source/playlunky/mod/mod_manager.h
+++ b/source/playlunky/mod/mod_manager.h
@@ -41,6 +41,7 @@ class ModManager
 
     std::filesystem::path mModsRoot;
 
+    bool mMenuShowOptions{ true };
     bool mForceShowOptions{ false };
     bool mShowCursor{ false };
 

--- a/source/playlunky/mod/script_manager.cpp
+++ b/source/playlunky/mod/script_manager.cpp
@@ -179,7 +179,7 @@ void ScriptManager::WindowDraw()
                         char by_author[128]{};
                         fmt::format_to(by_author, "by {}", meta.author);
                         const auto author_cursor_pos =
-                            ImGui::GetCursorPosX() + ImGui::GetWindowWidth() - ImGui::CalcTextSize(by_author).x - ImGui::GetScrollX() - 2 * ImGui::GetStyle().ItemSpacing.x;
+                            ImGui::GetCursorPosX() + ImGui::GetContentRegionMax().x - ImGui::CalcTextSize(by_author).x - ImGui::GetScrollX() - 2 * ImGui::GetStyle().ItemSpacing.x;
 
                         ImGui::Separator();
                         if (ImGui::Checkbox(meta.name, &mod.ScriptEnabled))

--- a/source/playlunky/mod/sprite_painter.cpp
+++ b/source/playlunky/mod/sprite_painter.cpp
@@ -186,7 +186,7 @@ void SpritePainter::WindowDraw()
 {
     const auto item_spacing = ImGui::GetStyle().ItemSpacing.x;
     const auto frame_padding = ImGui::GetStyle().FramePadding.x;
-    const auto window_width = ImGui::GetWindowWidth();
+    const auto window_width = ImGui::GetContentRegionMax().x;
 
     for (auto& sheet_ptr : m_RegisteredColorModSheets)
     {


### PR DESCRIPTION
- Enable mod options window scrollbar and other window controls. People had trouble scrolling through large options or wanted to hide the option window in the main menu, so now it can be closed or collapsed too. Collapsed state is saved to ini, but window is never completely hidden on launch.
- Fix mod savegame warning usually missing the actual mod name and printing only the extension "fyi"
- Add secondary almost invisible version overlay to the top. Everyone and their mom is covering the bottom corner with an input overlay or some kind of fursona, making the watermark useless
- Fix version overlay not showing up when dev console was enabled
