### PR TITLE
Increase result buffer size 512 to 5120 bytes for longer stack traces

### DIFF
--- a/source/playlunky/mod/script_manager.cpp
+++ b/source/playlunky/mod/script_manager.cpp
@@ -315,7 +315,7 @@ void ScriptManager::RegisteredMainScript::TestScriptResult()
     if (Script != nullptr)
     {
         using namespace std::literals::string_view_literals;
-        char res[512];
+        char res[5120];
         SpelunkyScript_GetResult(Script.get(), res, sizeof(res));
         if (res != "Got metadata"sv && res != "OK"sv && res != LastResult)
         {


### PR DESCRIPTION
## Observed (Problem)
Debug build of playlunky crashes in a call from `script_manager.cpp` to `SpelunkyScript_GetResult`, which ends with standard C library assertion on `strncpy_s` because it provides a 512 byte buffer which sometimes is too small for the result. The actual error i was trying to catch is longer (about 600 bytes).
<img width="1721" height="280" alt="зображення" src="https://github.com/user-attachments/assets/12ed2597-1112-45ef-84fc-75f649aac380" />

## Expected
I want to have my error messages in full and without an assertion crash.

## Solution
Increase receiving result buffer size.